### PR TITLE
Allow mtu task to configure multiple NICs

### DIFF
--- a/snaps_openstack/utilities/network_utils.py
+++ b/snaps_openstack/utilities/network_utils.py
@@ -166,7 +166,7 @@ def mtu(task):
             ansible_command = "ansible-playbook " + mtu_pb_loc + " -i \"" \
                               + ip + ",\"  --extra-vars=\'{\"size\": \"" \
                               + size + "\",\"interface\": \"" + port + "\"}\'"
-        logger.info(ansible_command)
-        ret = os.system(ansible_command)
+            logger.info(ansible_command)
+            ret = os.system(ansible_command)
 
     return ret


### PR DESCRIPTION
#### What does this PR do?
Allow mtu task to configure mtu settings of multiple NICs.

#### Do you have any concerns with this PR?
No

#### How can the reviewer verify this PR?
Run mtu config task with multiple NIC mtu settings.

#### Any background context you want to provide?
This was introduced by code restructuring and reformatting.

#### Screenshots or logs (if appropriate)
N/A

#### Questions:
- Have you connected this PR to the issue it resolves?
#116 

- Does the documentation need an update?
No

- Does this add new Python dependencies?
No

- Have you added unit or functional tests for this PR?
No, use existing integration testing for mtu config.
