### PR TITLE
Fix storage clean-up issue due to missing target info

### DIFF
--- a/snaps_openstack/ansible_p/ansible_utils/ansible_configuration.py
+++ b/snaps_openstack/ansible_p/ansible_utils/ansible_configuration.py
@@ -86,7 +86,7 @@ def clean_up_kolla(list_ip, git_branch, docker_registry, service_list,
             remove_storage_pb = pkg_resources.resource_filename(
                 consts.KOLLA_PB_PKG, consts.KOLLA_REMOVE_STORAGE)
             ret_storage = apbl.launch_ansible_playbook(
-                list_ip, remove_storage_pb, {
+                list_ip, remove_storage_pb, {'target':ip,
                     'PROXY_DATA_FILE': proxy_data_file,
                     'VARIABLE_FILE': variable_file,
                     'BASE_FILE_PATH': consts.KOLLA_SOURCE_PATH,


### PR DESCRIPTION
#### What does this PR do?
Fix storage clean-up issue due to missing host target information.

#### Do you have any concerns with this PR?
No

#### How can the reviewer verify this PR?
Run clean-up option for the snaps-openstack deployment.

#### Any background context you want to provide?
This issue was introduced when adding multiple ceph disk support.

#### Screenshots or logs (if appropriate)
N/A

#### Questions:
- Have you connected this PR to the issue it resolves?
#121 

- Does the documentation need an update?
No

- Does this add new Python dependencies?
No

- Have you added unit or functional tests for this PR?
No, using existing integration tests.
