### PR TITLE
Add neutron db vlan mapping cleanup workaround instructions

### DIFF
--- a/doc/source/install/install.md
+++ b/doc/source/install/install.md
@@ -651,4 +651,15 @@ Clean up previous vlan configuration:
 
 ```
 sudo python <repo_dir>/network_config.py -f <repo_dir>/snaps_openstack/utilities/var.yaml -tvclean
+
+Due to an upstream defect https://bugs.launchpad.net/neutron/+bug/1743425, apply the following
+workaround steps as well to remove the vlan mappings from neutron database:
+- ssh to control node: sudo ssh <control-node-ip>
+- From the wsrep_sst_auth attribute in /etc/kolla/mariadb/galera.cnf file, obtain the maria db
+credentials
+- Run interactive bash shell from mariadb container: docker exec -ti mariadb bash
+- Connect to neutron DB as root (enter root credential when prompted): mysql neutron -u root -p
+- Remove vlan mappings from neutron DB: TRUNCATE TABLE ml2_vlan_allocations;
+- Exit from neutron DB: exit
+- Exit from mariadb container interactive mode: exit
 ```


### PR DESCRIPTION
#### What does this PR do?
Add neutron db vlan mapping cleanup workaround instructions.

#### Do you have any concerns with this PR?
No

#### How can the reviewer verify this PR?
Follow the workaround steps.

#### Any background context you want to provide?
The workaround is needed due to an upstream defect https://bugs.launchpad.net/neutron/+bug/1743425

#### Screenshots or logs (if appropriate)
N/A

#### Questions:
- Have you connected this PR to the issue it resolves?
#118 

- Does the documentation need an update?
Yes, updated with this PR.

- Does this add new Python dependencies?
No.

- Have you added unit or functional tests for this PR?
No, use existing vlan cleanup test.