### PR TITLE
Make mtu configuration persistent

### DIFF
--- a/snaps_openstack/utilities/network_utils.py
+++ b/snaps_openstack/utilities/network_utils.py
@@ -169,4 +169,11 @@ def mtu(task):
             logger.info(ansible_command)
             ret = os.system(ansible_command)
 
+        restart_net_pb_loc = pkg_resources.resource_filename(
+            'snaps_openstack.utilities.playbooks', 'restart_network.yaml')
+        ansible_command_restart = "ansible-playbook " + restart_net_pb_loc \
+                                  + " --extra-vars=\'{\"target\": \"" + ip + "\"}\' "
+        logger.info("launching ansible :" + ansible_command_restart)
+        ret = os.system(ansible_command_restart)
+
     return ret

--- a/snaps_openstack/utilities/playbooks/restart_network.yaml
+++ b/snaps_openstack/utilities/playbooks/restart_network.yaml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017 ARICENT HOLDINGS LUXEMBOURG SARL. and
+# Copyright 2018 ARICENT HOLDINGS LUXEMBOURG SARL. and
 # Cable Television Laboratories, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,19 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- hosts: all
+- hosts: "{{ target }}"
   become: yes
   become_user: root
 #  vars_files:
 #  vars:
   tasks:
-   - name: Assign MTU on given interface
-     shell: ip link set dev {{ interface}} mtu {{ size }}
-   - name: insert MTU size for given interface in /etc/network/interfaces
-     blockinfile:
-       path: /etc/network/interfaces
-       marker: "# {mark} ANSIBLE MANAGED BLOCK {{ interface }}"
-       backup: yes
-       insertafter: "iface {{ interface }} inet static"
-       block: |
-         mtu {{ size }}
+    - name : Restart networking
+      shell: systemctl restart networking
+      ignore_errors: True


### PR DESCRIPTION
#### What does this PR do?
Make mtu configuration persistent.

#### Do you have any concerns with this PR?
No

#### How can the reviewer verify this PR?
Run MTU configuration per the installation guide.

#### Any background context you want to provide?
The original MTU configuration script did not put the MTU settings in /etc/network/interfaces file, therefore a network or system restart will revert the MTU changes.

#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
#111 
- Does the documentation need an update?
No
- Does this add new Python dependencies?
No
- Have you added unit or functional tests for this PR?
No, use existing MTU test.
