### PR TITLE
Fixes #138

### DIFF
--- a/snaps_openstack/ansible_p/commission/openstack/playbooks/deploy_mode/kolla/multinode_kolla_controller_pike.yaml
+++ b/snaps_openstack/ansible_p/commission/openstack/playbooks/deploy_mode/kolla/multinode_kolla_controller_pike.yaml
@@ -402,12 +402,15 @@
       async: 900
       register: out
       ignore_errors: True
-    - debug: var=out.stdout_lines
-    - debug: var=out.stderr_lines
+    - debug: var=out.ansible_job_id
 
-    - name: Validating task [run init-runonce] returned 0
-      fail: msg="run init-runonce command failed"
-      when: out.rc != 0
+    - name: Validating task [run init-runonce] is successful
+      async_status:
+        jid: "{{ out.ansible_job_id }}"
+      register: job_result
+      until: job_result.finished
+      retries: 60
+      delay: 15
 
     - name: fetching external routes
       shell: route -A inet6 | grep '{{ neutron_external_interface }}' | awk {'print $1'}


### PR DESCRIPTION
#### What does this PR do?
Fixes the way to validate the success of async task init-runonce.

#### Do you have any concerns with this PR?
No

#### How can the reviewer verify this PR?
Run snaps-openstack deploy script.

#### Any background context you want to provide?
No

#### Screenshots or logs (if appropriate)
The new script output:
TASK [debug] *******************************************************************
ok: [10.197.111.12] => {
    "out.ansible_job_id": "267110301958.3489"
}

TASK [Validating task [run init-runonce] is successful] ************************
FAILED - RETRYING: TASK: Validating task [run init-runonce] is successful (59 retries left). Result was: {u'ansible_job_id': u'267110301958.3489', u'started': 1, u'changed': False, u'finished': 0, u'results_file': u'/root/.ansible_async/267110301958.3489', 'invocation': {'module_name': u'async_status', u'module_args': {u'jid': u'267110301958.3489', u'mode': u'status'}}}
FAILED - RETRYING: TASK: Validating task [run init-runonce] is successful (58 retries left). Result was: {u'ansible_job_id': u'267110301958.3489', u'started': 1, u'changed': False, u'finished': 0, u'results_file': u'/root/.ansible_async/267110301958.3489', 'invocation': {'module_name': u'async_status', u'module_args': {u'jid': u'267110301958.3489', u'mode': u'status'}}}
FAILED - RETRYING: TASK: Validating task [run init-runonce] is successful (57 retries left). Result was: {u'ansible_job_id': u'267110301958.3489', u'started': 1, u'changed': False, u'finished': 0, u'results_file': u'/root/.ansible_async/267110301958.3489', 'invocation': {'module_name': u'async_status', u'module_args': {u'jid': u'267110301958.3489', u'mode': u'status'}}}
FAILED - RETRYING: TASK: Validating task [run init-runonce] is successful (56 retries left). Result was: {u'ansible_job_id': u'267110301958.3489', u'started': 1, u'changed': False, u'finished': 0, u'results_file': u'/root/.ansible_async/267110301958.3489', 'invocation': {'module_name': u'async_status', u'module_args': {u'jid': u'267110301958.3489', u'mode': u'status'}}}
FAILED - RETRYING: TASK: Validating task [run init-runonce] is successful (55 retries left). Result was: {u'ansible_job_id': u'267110301958.3489', u'started': 1, u'changed': False, u'finished': 0, u'results_file': u'/root/.ansible_async/267110301958.3489', 'invocation': {'module_name': u'async_status', u'module_args': {u'jid': u'267110301958.3489', u'mode': u'status'}}}
FAILED - RETRYING: TASK: Validating task [run init-runonce] is successful (54 retries left). Result was: {u'ansible_job_id': u'267110301958.3489', u'started': 1, u'changed': False, u'finished': 0, u'results_file': u'/root/.ansible_async/267110301958.3489', 'invocation': {'module_name': u'async_status', u'module_args': {u'jid': u'267110301958.3489', u'mode': u'status'}}}
FAILED - RETRYING: TASK: Validating task [run init-runonce] is successful (53 retries left). Result was: {u'ansible_job_id': u'267110301958.3489', u'started': 1, u'changed': False, u'finished': 0, u'results_file': u'/root/.ansible_async/267110301958.3489', 'invocation': {'module_name': u'async_status', u'module_args': {u'jid': u'267110301958.3489', u'mode': u'status'}}}
FAILED - RETRYING: TASK: Validating task [run init-runonce] is successful (52 retries left). Result was: {u'ansible_job_id': u'267110301958.3489', u'started': 1, u'changed': False, u'finished': 0, u'results_file': u'/root/.ansible_async/267110301958.3489', 'invocation': {'module_name': u'async_status', u'module_args': {u'jid': u'267110301958.3489', u'mode': u'status'}}}
FAILED - RETRYING: TASK: Validating task [run init-runonce] is successful (51 retries left). Result was: {u'ansible_job_id': u'267110301958.3489', u'started': 1, u'changed': False, u'finished': 0, u'results_file': u'/root/.ansible_async/267110301958.3489', 'invocation': {'module_name': u'async_status', u'module_args': {u'jid': u'267110301958.3489', u'mode': u'status'}}}
FAILED - RETRYING: TASK: Validating task [run init-runonce] is successful (50 retries left). Result was: {u'ansible_job_id': u'267110301958.3489', u'started': 1, u'changed': False, u'finished': 0, u'results_file': u'/root/.ansible_async/267110301958.3489', 'invocation': {'module_name': u'async_status', u'module_args': {u'jid': u'267110301958.3489', u'mode': u'status'}}}
FAILED - RETRYING: TASK: Validating task [run init-runonce] is successful (49 retries left). Result was: {u'ansible_job_id': u'267110301958.3489', u'started': 1, u'changed': False, u'finished': 0, u'results_file': u'/root/.ansible_async/267110301958.3489', 'invocation': {'module_name': u'async_status', u'module_args': {u'jid': u'267110301958.3489', u'mode': u'status'}}}
changed: [10.197.111.12]

#### Questions:
- Have you connected this PR to the issue it resolves?
#138 
- Does the documentation need an update?
No
- Does this add new Python dependencies?
No
- Have you added unit or functional tests for this PR?
No, uses existing tests.
