### PR TITLE
Configurable flavor metadata for CI

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -92,11 +92,15 @@ pub_iface: ens5
 build_kp_pub_path: /tmp/build-kp-lab3.pub
 build_kp_priv_path: /tmp/build-kp-lab3
 
-deployment_yaml_target_path: /tmp/deployment.yaml
-
 node_host_password: Pa$$w0rd
 
 local_snaps_openstack_dir: /home/ubuntu/snaps-openstack
+
+# Optional - When the flavors created require special metadata
+#flavor_metadata:
+#  hw:cpu_policy: dedicated
+#  hw:cpu_thread_policy: isolate
+
 ```
 4. Launch the test
 This is best to do in a screen session and redirect the output.

--- a/ci/playbooks/deploy_os.yaml
+++ b/ci/playbooks/deploy_os.yaml
@@ -101,11 +101,11 @@
     - name: Restart Node 3 sys-kernel-config.mount
       command: "ssh root@{{ admin_ip_3 }} 'systemctl restart sys-kernel-config.mount'"
 
-    - name: Apply template and copy deployment.yaml.tmplt to {{ deployment_yaml_path }}
-      action: template src=templates/deployment.yaml.tmplt dest={{ deployment_yaml_path }}
+    - name: Apply template and copy deployment.yaml.tmplt to {{ src_copy_dir }}/deployment.yaml
+      action: template src=templates/deployment.yaml.tmplt dest={{ src_copy_dir }}/deployment.yaml
 
     - name: Deploy - iaas_launch.py -d *** This will run for around an hour without output
-      command: "python {{ src_copy_dir }}/snaps-openstack/iaas_launch.py -f {{ deployment_yaml_path }} -d"
+      command: "python {{ src_copy_dir }}/snaps-openstack/iaas_launch.py -f {{ src_copy_dir }}/deployment.yaml -d"
       register: out
       ignore_errors: True
     - debug: var=out.stdout_lines

--- a/ci/snaps/env.yaml.tmplt
+++ b/ci/snaps/env.yaml.tmplt
@@ -1,0 +1,41 @@
+---
+# Used for naming shared objects created by the 'admin' user
+build_id: {{ build_id }}
+
+admin_user: admin
+admin_proj: admin
+admin_pass: {{ os_pass }}
+auth_url: http://{{ auth_url}}
+id_api_version: 3
+proxy_host:
+proxy_port:
+ssh_proxy_cmd:
+
+os_user_pass: password
+
+ext_net: public1
+ext_subnet: public1-subnet
+
+src_copy_dir: /tmp
+
+ctrl_ip_prfx: 10.0.0
+admin_ip_prfx: 10.1.0
+admin_iface: ens3
+priv_ip_prfx: 10.1.1
+priv_iface: ens4
+pub_ip_prfx: 10.1.2
+pub_iface: ens5
+
+build_kp_pub_path: {{ where_to_create_key }}.pub
+build_kp_priv_path: {{ where_to_create_key }}
+
+deployment_yaml_target_path: /tmp/deployment.yaml
+
+node_host_password: Pa$$w0rd
+
+local_snaps_openstack_dir: {{ path_to_snaps-openstack }}
+
+# Optional - When the flavors created require special metadata
+#flavor_metadata:
+#  hw:cpu_policy: dedicated
+#  hw:cpu_thread_policy: isolate

--- a/ci/snaps/snaps_os_tmplt.yaml
+++ b/ci/snaps/snaps_os_tmplt.yaml
@@ -50,18 +50,36 @@ openstack:
         ram: 8192
         disk: 100
         vcpus: 4
+{% if flavor_metadata is defined %}
+        metadata:
+        {% for key, value in flavor_metadata.iteritems() %}
+          {{ key }}: {{ value }}
+        {% endfor %}
+{% endif %}
     - flavor:
         os_creds_name: admin-creds
         name: os-control-flavor-{{ build_id }}
         ram: 24576
         disk: 300
         vcpus: 8
+{% if flavor_metadata is defined %}
+        metadata:
+        {% for key, value in flavor_metadata.iteritems() %}
+          {{ key }}: {{ value }}
+        {% endfor %}
+{% endif %}
     - flavor:
         os_creds_name: admin-creds
         name: os-compute-flavor-{{ build_id }}
         ram: 16384
         disk: 300
         vcpus: 8
+{% if flavor_metadata is defined %}
+        metadata:
+        {% for key, value in flavor_metadata.iteritems() %}
+          {{ key }}: {{ value }}
+        {% endfor %}
+{% endif %}
   images:
     - image:
         os_creds_name: admin-creds
@@ -601,9 +619,6 @@ ansible:
       pub_iface:
         type: string
         value: {{ pub_iface }}
-      deployment_yaml_path:
-        type: string
-        value: {{ deployment_yaml_target_path }}
       node_host_pass:
         type: string
         value: {{ node_host_password }}


### PR DESCRIPTION
Added the ability to configure any flavor metadata to the VMs being spawned.

Also removed the required attribute "deployment_yaml_target_path" from the CI environment file.

#### What does this PR do?
Makes the CI scripts more flexible based on how the OpenStack pod has been configured
#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
execute CI with some special flavor metadata (and not seeing that it is optional)
#### Any background context you want to provide?
Randy asked for this especially as we have seen some issues around large pagesizes and CPU pinning
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
n/a
- Does the documentation need an update?
Updated the CI README.md file
- Does this add new Python dependencies?
no
- Have you added unit or functional tests for this PR?
no
- Does this patch update any configuration files?
Only optionally the CI environment file. Added an example of how it should work (env.yaml.tmplt)